### PR TITLE
improved imp_steps

### DIFF
--- a/examples/knot/KnotMainImp0proof.v
+++ b/examples/knot/KnotMainImp0proof.v
@@ -43,6 +43,7 @@ Section SIMMODSEM.
       (<<TGT: mrps_tgt0 = tt↑>>)
   .
 
+
   Theorem correct:
     refines2 [KnotMainImp.KnotMain] [KnotMain0.Main].
   Proof.
@@ -67,7 +68,6 @@ Section SIMMODSEM.
         unfold unint in *. des_ifs; ss; clarify.
         { lia. }
         imp_steps.
-        unfold unblk in *. ss; clarify. rewrite _UNWRAPU0.
         unfold ccallU. imp_steps.
         red. esplits; et.
     }
@@ -81,8 +81,6 @@ Section SIMMODSEM.
       2:{ exfalso; apply n0. solve_NoDup. }
       imp_steps.
       rewrite _UNWRAPU0. unfold ccallU. imp_steps.
-      unfold unblk in *. ss; clarify. rewrite _UNWRAPU3.
-      imp_steps.
       red. esplits; et.
     }
     Unshelve. all: ss. all: try exact 0.

--- a/examples/stack/StackImp0proof.v
+++ b/examples/stack/StackImp0proof.v
@@ -43,9 +43,12 @@ Section SIMMODSEM.
       (<<TGT: mrps_tgt0 = tt↑>>)
   .
 
+  (* Ltac imp_steps := repeat (repeat (imp_red); steps). *)
+
   Theorem correct:
     refines2 [StackImp.Stack] [Stack0.Stack].
   Proof.
+    (* Set Ltac Profiling. *)
     eapply adequacy_local2. econs; ss. i.
     econstructor 1 with (wf:=wf) (le:=top2); et; ss.
     econs; ss.
@@ -86,7 +89,8 @@ Section SIMMODSEM.
         uo. des_ifs_safe; ss; clarify. unfold scale_int in Heq2.
         des_ifs_safe. steps. imp_steps.
         unfold scale_int. uo; ss. des_ifs. ss.
-        rewrite Z_div_same; ss. rewrite Z.add_0_l. imp_steps.
+        rewrite Z_div_same; ss. rewrite Z.add_0_l.
+        imp_steps.
         red. esplits; et.
       - apply Z.eqb_neq in N1.
         destruct (val_dec (Vint 0) (Vint 0)); ss.
@@ -105,12 +109,14 @@ Section SIMMODSEM.
       unfold unblk in *. des_ifs.
       imp_steps.
       unfold ccallU. imp_steps.
-      rewrite _UNWRAPU1. imp_steps.
+      rewrite _UNWRAPU1.
+      imp_steps.
       uo; des_ifs; ss; clarify.
       2:{ unfold scale_int in *. des_ifs. }
       imp_steps.
       red. esplits; et.
     }
+    (* Show Ltac Profile. *)
     Unshelve. all: try exact 0. all: ss.
   Qed.
 

--- a/imp/definition/ImpProofs.v
+++ b/imp/definition/ImpProofs.v
@@ -397,6 +397,23 @@ Section PROOFS.
     unfold pure_state. grind.
   Qed.
 
+  Lemma interp_imp_guarantee
+        ge le0 p
+    :
+      interp_imp ge (guarantee p) le0 = guarantee p;;; tau;; tau;; Ret (le0, ()).
+  Proof.
+    unfold interp_imp, interp_GlobEnv, interp_ImpState.
+    unfold guarantee. grind. rewrite interp_trigger. grind.
+    unfold pure_state. grind.
+  Qed.
+
+  Lemma interp_Es_ext
+        ge R (itr0 itr1: itree _ R) le0
+    :
+      itr0 = itr1 -> interp_imp ge itr0 le0 = interp_imp ge itr1 le0
+  .
+  Proof. i; subst; refl. Qed.
+
   Lemma interp_imp_expr_Var
         ge le0 v
     :
@@ -848,6 +865,8 @@ Global Opaque denote_stmt.
 Global Opaque interp_imp.
 Global Opaque eval_imp.
 
+Require Import Red IRed.
+
 Require Import SimModSem.
 Require Import HTactics.
 Require Import ImpNotations.
@@ -900,5 +919,5 @@ Ltac imp_red :=
   | _ => idtac
   end.
 
-Ltac imp_steps := repeat (repeat imp_red; steps).
+Ltac imp_steps := repeat (repeat (imp_red; ss); steps).
 Ltac solve_NoDup := repeat econs; ii; ss; des; ss.


### PR DESCRIPTION
New imp_steps performs `ss` tactic for every `imp_red`. When terms are reduced with `ss`, this results in overall performance improvement.
Tested with Ltac profiling: `examples/stack/StackImp0proof.v`, `correctness` proof. (suggested by @minkiminki )
Only the second column is important (contribution to the total time)
1) without `ss`:
```
total time:    128.029s
─imp_steps -----------------------------   0.1%  93.2%      15   32.937s
 ├─steps -------------------------------   0.0%  77.4%     120    8.658s
 │ ├─ired_both -------------------------   0.0%  34.6%     502    6.264s
 │ │ ├─ired_r --------------------------   0.0%  28.1%     502    5.287s
 │ │ │└Red._prw ------------------------   0.0%  28.1%     266    5.275s
 │ │ │ ├─k1 ----------------------------   0.0%  20.2%     397    3.818s
 │ │ │ │ ├─Red.__prw -------------------   2.7%  10.0%     230    1.983s
 │ │ │ │ │ ├─red_tac -------------------   0.0%   4.5%     230    0.865s
 │ │ │ │ │ │└IRed._red_interp ----------   0.0%   4.4%       0    0.865s
 │ │ │ │ │ │└apply IRed.bind_ext -------   2.6%   2.6%     452    0.544s
 │ │ │ │ │ └─etransitivity -------------   2.3%   2.3%     359    0.484s
 │ │ │ │ ├─red_tac ---------------------   0.0%   6.7%     397    1.179s
 │ │ │ │ │ ├─IRed._red_interp ----------   0.0%   4.6%       0    0.798s
 │ │ │ │ │ │└apply IRed.bind_ext -------   2.7%   2.7%     736    0.488s
 │ │ │ │ │ └─IRed._red_itree -----------   0.0%   2.0%       0    0.381s
 │ │ │ │ └─etransitivity ---------------   2.6%   2.6%     528    0.501s
 │ │ │ ├─k0 ----------------------------   2.9%   5.6%    1584    1.000s
 │ │ │ │└Red._ctx ----------------------   0.0%   5.6%    1056    0.503s
 │ │ │ │└apply f_equal -----------------   5.6%   5.6%     794    0.503s
 │ │ │ └─eapply Red._einit -------------   2.3%   2.3%     528    0.456s
 │ │ └─ired_l --------------------------   0.0%   6.5%     502    0.977s
 │ │  └Red._prw ------------------------   0.0%   6.5%      37    0.976s
 │ │   ├─k0 ----------------------------   3.4%   3.6%    2271    0.595s
 │ │   │└Red._ctx ----------------------   0.3%   3.5%    1911    0.594s
 │ │   │└apply Red._equal_f ------------   3.1%   3.1%     397    0.593s
 │ │   └─eapply Red._einit -------------   2.2%   2.2%     757    0.422s
 │ ├─_step -----------------------------   0.0%  24.8%     397    1.829s
 │ │ ├─tac -----------------------------   0.0%  10.2%   39942    0.139s
 │ │ │└by (ssrhintarg) -----------------   0.0%  10.1%     336    0.139s
 │ │ │└done ----------------------------   0.1%   9.1%     167    0.131s
 │ │ │└fast_done -----------------------   0.0%   4.9%     346    0.039s
 │ │ │ ├─symmetry ----------------------   2.0%   2.0%     349    0.018s
 │ │ │ └─reflexivity -------------------   2.0%   2.0%     334    0.018s
 │ │ ├─gstep ---------------------------   0.0%   8.4%     596    1.189s
 │ │ │└under_forall --------------------   0.0%   8.4%     596    1.189s
 │ │ │ ├─tac ---------------------------   2.3%   4.9%     596    0.786s
 │ │ │ │└gstep_ ------------------------   0.0%   2.6%    1710    0.423s
 │ │ │ │└eapply gpaco8_step ------------   2.4%   2.4%     374    0.423s
 │ │ │ └─generalize pacotac_internal._pa   3.3%   3.3%     604    0.373s
 │ │ └─eapply safe_sim_sim -------------   2.8%   2.8%     583    0.507s
 │ └─des_ifs_safe_aux ------------------   0.1%  17.5%     502    0.717s
 │  └TAC -------------------------------   0.1%  16.2%     713    0.162s
 │  └sflib__clarify1 -------------------   0.1%  16.1%     713    0.161s
 │   ├─SimComp.sflib.done --------------   0.1%  10.1%     711    0.062s
 │   │└sflib__basic_done ---------------   0.1%   8.4%    1410    0.024s
 │   │└discriminate --------------------   8.1%   8.1%    1323    0.023s
 │   └─rewrite H in * ------------------   5.4%   5.4%    1587    0.042s
 └─imp_red -----------------------------   0.1%  15.7%     330    1.443s
  └rewrite interp_imp_bind -------------  13.6%  13.6%     225    1.250s
```
2) with `ss`:
```
total time:     62.594s
─imp_steps -----------------------------   0.0%  85.7%      15   15.953s
 ├─steps -------------------------------   0.1%  77.0%     120    7.076s
 │ ├─des_ifs_safe_aux ------------------   0.1%  33.7%     478    0.717s
 │ │└TAC -------------------------------   0.1%  31.1%     679    0.166s
 │ │└sflib__clarify1 -------------------   0.3%  31.0%     679    0.166s
 │ │ ├─SimComp.sflib.done --------------   0.2%  19.5%     672    0.064s
 │ │ │ ├─sflib__basic_done -------------   0.1%  16.1%    1332    0.030s
 │ │ │ │└discriminate ------------------  15.6%  15.6%    1249    0.030s
 │ │ │ └─split -------------------------   2.3%   2.3%    2158    0.005s
 │ │ └─rewrite H in * ------------------  10.4%  10.4%    1490    0.035s
 │ ├─_step -----------------------------   0.1%  32.3%     373    0.185s
 │ │ ├─tac -----------------------------   0.0%  20.7%   38904    0.143s
 │ │ │└by (ssrhintarg) -----------------   0.0%  20.5%     336    0.143s
 │ │ │ ├─done --------------------------   0.1%  18.5%     167    0.137s
 │ │ │ │ ├─fast_done -------------------   0.1%  10.0%     346    0.038s
 │ │ │ │ │ ├─symmetry ------------------   4.1%   4.1%     349    0.018s
 │ │ │ │ │ └─reflexivity ---------------   4.1%   4.1%     334    0.018s
 │ │ │ │ ├─symmetry --------------------   4.0%   4.0%     306    0.018s
 │ │ │ │ └─discriminate ----------------   3.3%   3.3%     306    0.025s
 │ │ │ └─oauto -------------------------   2.1%   2.1%     323    0.015s
 │ │ └─gstep ---------------------------   0.0%   5.0%     548    0.014s
 │ │  └under_forall --------------------   0.0%   5.0%     548    0.014s
 │ │   ├─generalize pacotac_internal._pa   2.7%   2.7%     556    0.008s
 │ │   └─tac ---------------------------   0.8%   2.2%     548    0.008s
 │ └─ired_both -------------------------   0.0%  10.5%     478    0.036s
 │   ├─ired_r --------------------------   0.0%   6.6%     478    0.026s
 │   │└Red._prw ------------------------   0.0%   6.5%     242    0.026s
 │   │└k1 ------------------------------   0.1%   4.2%     373    0.020s
 │   └─ired_l --------------------------   0.0%   4.0%     478    0.025s
 │    └Red._prw ------------------------   0.0%   3.9%      37    0.025s
 ├─simpls ------------------------------   0.0%   5.3%     295    0.101s
 │└SimComp.sflib.done ------------------   0.0%   4.9%     190    0.101s
 │└sflib__basic_done -------------------   0.0%   3.7%     376    0.023s
 │└discriminate ------------------------   3.6%   3.6%     376    0.023s
 └─imp_red -----------------------------   0.2%   3.4%     309    0.033s
```
As one can see, total time is halved, and `imp_red`'s contribution is significantly reduced (15.7% -> 3.4%).
